### PR TITLE
Allocate Ergonomics

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .zig_typeid,
-    .version = "3.0.0",
+    .version = "4.0.0",
     .fingerprint = 0x42206bb5100b2934,
     .dependencies = .{},
     .paths = .{

--- a/src/base32.zig
+++ b/src/base32.zig
@@ -4,7 +4,7 @@ const uuid = @import("uuid.zig");
 
 const alphabet = "0123456789abcdefghjkmnpqrstvwxyz";
 
-pub fn encode(s: [16]u8) ![26]u8 {
+pub fn encode(s: [16]u8) [26]u8 {
     var dst: [26]u8 = undefined;
     // 10 byte timestamp
     dst[0] = alphabet[(s[0] & 224) >> 5];
@@ -41,7 +41,7 @@ pub fn encode(s: [16]u8) ![26]u8 {
 
 fn from_str(s: []const u8) ![26]u8 {
     const src: [16]u8 = try uuid.from(s);
-    return try encode(src);
+    return encode(src);
 }
 
 test "encode" {

--- a/src/typeid.zig
+++ b/src/typeid.zig
@@ -74,10 +74,7 @@ pub fn from(allocator: std.mem.Allocator, comptime prefix: []const u8, uuid: [16
     if (prefix[prefix.len - 1] == '_')
         @compileError("Prefix cannot end with '_'");
 
-    const buf = try allocator.alloc(u8, prefix.len + typeid_suffix_len + 1);
-    @memcpy(buf, prefix ++ "_" ++ base32.encode(uuid));
-
-    return buf;
+    return std.fmt.allocPrint(allocator, "{s}_{s}", .{ prefix, base32.encode(uuid) });
 }
 
 test from {

--- a/src/typeid.zig
+++ b/src/typeid.zig
@@ -81,24 +81,21 @@ test from {
     var arena: std.heap.ArenaAllocator = .init(std.testing.allocator);
     defer arena.deinit();
     const @"🐑" = arena.allocator();
-    var foo: []const u8 = undefined;
 
-    // Add scoping to validate lifetime
-    {
-        foo = try from(@"🐑", "foo", try UUID.from("01889c89-df6b-7f1c-a388-91396ec314bc"));
-        try std.testing.expectEqualStrings(
-            "foo_01h2e8kqvbfwea724h75qc655w",
-            foo,
-        );
-
-        try std.testing.expectEqualStrings(
-            "baa_01h2e8kqvbfwea724h75qc655w",
-            try from(@"🐑", "baa", try UUID.from("01889c89-df6b-7f1c-a388-91396ec314bc")),
-        );
-    }
+    const foo = try from(@"🐑", "foo", try UUID.from("01889c89-df6b-7f1c-a388-91396ec314ba"));
+    try std.testing.expectEqualStrings(
+        "foo_01h2e8kqvbfwea724h75qc655t",
+        foo,
+    );
 
     try std.testing.expectEqualStrings(
-        "foo_01h2e8kqvbfwea724h75qc655w",
+        "baa_01h2e8kqvbfwea724h75qc655w",
+        try from(@"🐑", "baa", try UUID.from("01889c89-df6b-7f1c-a388-91396ec314bc")),
+    );
+
+    // Previously generated IDs are not invalidated
+    try std.testing.expectEqualStrings(
+        "foo_01h2e8kqvbfwea724h75qc655t",
         foo,
     );
 }


### PR DESCRIPTION
Change from and from_string to allocate
The usage pattern turned out to always be:

```
const id = allocator.alloc(u8, prefix.len + 27);
id.* = try typeId.from_string(prefix, uuid);
```

i.e. there was never any convenience of just working with a static
array, as the variable size made it clunky to deal with.  It also
meant the client code had to know how to calculate the memory
requirements.

Therefore, the alloc behavior makes sense to bake into this library.